### PR TITLE
hotfix after tflint and checkov

### DIFF
--- a/04/src/main.tf
+++ b/04/src/main.tf
@@ -33,7 +33,7 @@ module "my_db_and_user" {
 
 
 module "test-vm" {
-  source          = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
+  source          = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=1.0.0"
   env_name        = "develop"
   network_id      = yandex_vpc_network.develop.id
   subnet_zones    = ["ru-central1-a"]
@@ -58,7 +58,7 @@ data "template_file" "cloudinit" {
   }
 }
 
-/*
+
 data "vault_generic_secret" "vault_example"{
  path = "secret/example"
 }
@@ -75,7 +75,6 @@ EOT
 }
 
 output "vault_example" {
- value = "${nonsensitive(data.vault_generic_secret.vault_example.data)}"
+ value = nonsensitive(data.vault_generic_secret.vault_example.data)
 }
 
-*/

--- a/04/src/modules/my_claster/claster.tf
+++ b/04/src/modules/my_claster/claster.tf
@@ -19,6 +19,7 @@ resource "yandex_mdb_mysql_cluster" "example" {
   name        = var.cl_params.name
   environment = "PRESTABLE"
   network_id  = var.cl_params.net_id
+  security_group_ids  = [ yandex_vpc_security_group.test-sg.id ]
   version     = "8.0"
 
   resources {
@@ -38,6 +39,27 @@ resource "yandex_mdb_mysql_cluster" "example" {
       subnet_id = host.value.id
       name = host.value.name
     }
+  }
+}
+
+resource "yandex_vpc_security_group" "test-sg" {
+  name        = "Test security group"
+  description = "Description for security group"
+  network_id  = var.cl_params.net_id
+
+  ingress {
+    protocol       = "TCP"
+    description    = "Rule description 1"
+    v4_cidr_blocks = ["10.0.1.0/24", "10.0.2.0/24"]
+    port           = 8080
+  }
+
+  egress {
+    protocol       = "ANY"
+    description    = "Rule description 2"
+    v4_cidr_blocks = ["10.0.1.0/24", "10.0.2.0/24"]
+    from_port      = 8090
+    to_port        = 8099
   }
 }
 

--- a/04/src/providers.tf
+++ b/04/src/providers.tf
@@ -1,7 +1,16 @@
 terraform {
   required_providers {
     yandex = {
-      source = "yandex-cloud/yandex"
+      source  = "yandex-cloud/yandex"
+      version = "~>0.90"
+    }
+    template = {
+      source  = "hashicorp/template"
+      version = "~> 2"
+    }
+    vault = {
+      source  = "hashicorp/vault"
+      version = "~> 2"
     }
   }
 
@@ -26,10 +35,9 @@ provider "yandex" {
   folder_id = var.folder_id
   zone      = var.default_zone
 }
-/*
+
 provider "vault" {
  address = "http://localhost:8200"
  skip_tls_verify = true
- token = "education"
+ token = var.vault_token
 }
-*/

--- a/04/src/variables.tf
+++ b/04/src/variables.tf
@@ -14,12 +14,17 @@ variable "folder_id" {
   description = "https://cloud.yandex.ru/docs/resource-manager/operations/folder/get-id"
 }
 
+variable "vault_token" {
+  type        = string
+  description = "Vault token"
+}
+
 variable "default_zone" {
   type        = string
   default     = "ru-central1-a"
   description = "https://cloud.yandex.ru/docs/overview/concepts/geo-scope"
 }
-variable "default_cidr" {
+/*variable "default_cidr" {
   type        = list(string)
   default     = ["10.0.1.0/24"]
   description = "https://cloud.yandex.ru/docs/vpc/operations/subnet-create"
@@ -70,7 +75,7 @@ variable "pub_keys_fn" {
   type    = list
   default = [ "/home/beatl/.ssh/id_ed25519.pub", "/home/beatl/.ssh/id_rsa.pub" ]
 }
-
+*/
 
 
 


### PR DESCRIPTION
_All errors are fixed except : ***Check: CKV_TF_1: "Ensure Terraform module sources use a commit hash"***
I couldn't figure out how to fix it_

----

```
beatl@ProBookB:~/ter-homeworks/04/src$ tflint
12 issue(s) found:

Warning: Module source "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main" uses a default branch as ref (main) (terraform_module_pinned_source)

  on main.tf line 36:
  36:   source          = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.4.0/docs/rules/terraform_module_pinned_source.md

Warning: Missing version constraint for provider "template" in `required_providers` (terraform_required_providers)

  on main.tf line 53:
  53: data "template_file" "cloudinit" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.4.0/docs/rules/terraform_required_providers.md

Warning: [Fixable] Interpolation-only expressions are deprecated in Terraform v0.12.14 (terraform_deprecated_interpolation)

  on main.tf line 78:
  78:  value = "${nonsensitive(data.vault_generic_secret.vault_example.data)}"

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.4.0/docs/rules/terraform_deprecated_interpolation.md

Warning: Missing version constraint for provider "yandex" in `required_providers` (terraform_required_providers)

  on providers.tf line 3:
   3:     yandex = {
   4:       source = "yandex-cloud/yandex"
   5:     }

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.4.0/docs/rules/terraform_required_providers.md

Warning: Missing version constraint for provider "vault" in `required_providers` (terraform_required_providers)

  on providers.tf line 30:
  30: provider "vault" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.4.0/docs/rules/terraform_required_providers.md

Warning: [Fixable] variable "default_cidr" is declared but not used (terraform_unused_declarations)

  on variables.tf line 22:
  22: variable "default_cidr" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.4.0/docs/rules/terraform_unused_declarations.md

Warning: [Fixable] variable "vpc_name" is declared but not used (terraform_unused_declarations)

  on variables.tf line 28:
  28: variable "vpc_name" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.4.0/docs/rules/terraform_unused_declarations.md

Warning: [Fixable] variable "subnets" is declared but not used (terraform_unused_declarations)

  on variables.tf line 34:
  34: variable "subnets" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.4.0/docs/rules/terraform_unused_declarations.md

Warning: [Fixable] variable "vms_ssh_root_key" is declared but not used (terraform_unused_declarations)

  on variables.tf line 49:
  49: variable "vms_ssh_root_key" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.4.0/docs/rules/terraform_unused_declarations.md

Warning: [Fixable] variable "vm_web_name" is declared but not used (terraform_unused_declarations)

  on variables.tf line 56:
  56: variable "vm_web_name" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.4.0/docs/rules/terraform_unused_declarations.md

Warning: [Fixable] variable "vm_db_name" is declared but not used (terraform_unused_declarations)

  on variables.tf line 63:
  63: variable "vm_db_name" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.4.0/docs/rules/terraform_unused_declarations.md

Warning: [Fixable] variable "pub_keys_fn" is declared but not used (terraform_unused_declarations)

  on variables.tf line 69:
  69: variable "pub_keys_fn" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.4.0/docs/rules/terraform_unused_declarations.md

beatl@ProBookB:~/ter-homeworks/04/src$ checkov -d .
2023-08-14 12:56:29,270 [MainThread  ] [WARNI]  Failed to get the checkov mappings and guidelines from https://www.bridgecrew.cloud/api/v2/guidelines. Skips using BC_* IDs will not work.
Traceback (most recent call last):
  File "/home/beatl/.local/lib/python3.9/site-packages/checkov/common/bridgecrew/platform_integration.py", line 820, in get_public_run_config
    self.public_metadata_response = json.loads(request.data.decode("utf8"))
  File "/usr/lib/python3.9/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.9/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.9/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
2023-08-14 12:56:29,304 [MainThread  ] [WARNI]  Failed to download module git::https://github.com/udjin10/yandex_compute_instance.git?ref=main:None (for external modules, the --download-external-modules flag is required)
[ kubernetes framework ]: 100%|████████████████████|[1/1], Current File Scanned=cloud-init.yml
[ ansible framework ]: 100%|████████████████████|[1/1], Current File Scanned=cloud-init.yml
[ secrets framework ]: 100%|████████████████████|[9/9], Current File Scanned=./modules/my_vpc/my_vpc_module.tf
[ terraform framework ]: 100%|████████████████████|[6/6], Current File Scanned=variables.tf                   

       _               _              
   ___| |__   ___  ___| | _______   __
  / __| '_ \ / _ \/ __| |/ / _ \ \ / /
 | (__| | | |  __/ (__|   < (_) \ V / 
  \___|_| |_|\___|\___|_|\_\___/ \_/  
                                      
By bridgecrew.io | version: 2.3.364 

terraform scan results:

Passed checks: 1, Failed checks: 2, Skipped checks: 0

Check: CKV_YC_12: "Ensure public IP is not assigned to database cluster."
        PASSED for resource: yandex_mdb_mysql_cluster.example
        File: /modules/my_claster/claster.tf:18-42
Check: CKV_TF_1: "Ensure Terraform module sources use a commit hash"
        FAILED for resource: test-vm
        File: /main.tf:35-51

                35 | module "test-vm" {
                36 |   source          = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
                37 |   env_name        = "develop"
                38 |   network_id      = yandex_vpc_network.develop.id
                39 |   subnet_zones    = ["ru-central1-a"]
                40 |   subnet_ids      = [ yandex_vpc_subnet.develop.id ]
                41 |   instance_name   = "web"
                42 |   instance_count  = 1
                43 |   image_family    = "ubuntu-2004-lts"
                44 |   public_ip       = true
                45 | 
                46 |   metadata = {
                47 |       user-data          = data.template_file.cloudinit.rendered #Для демонстрации №3
                48 |       serial-port-enable = 1
                49 |   }
                50 | 
                51 | }

Check: CKV_YC_1: "Ensure security group is assigned to database cluster."
        FAILED for resource: yandex_mdb_mysql_cluster.example
        File: /modules/my_claster/claster.tf:18-42

                18 | resource "yandex_mdb_mysql_cluster" "example" {
                19 |   name        = var.cl_params.name
                20 |   environment = "PRESTABLE"
                21 |   network_id  = var.cl_params.net_id
                22 |   version     = "8.0"
                23 | 
                24 |   resources {
                25 |     resource_preset_id = "s2.micro"
                26 |     disk_type_id       = "network-ssd"
                27 |     disk_size          = 16
                28 |   }
                29 | 
                30 |   maintenance_window {
                31 |     type = "ANYTIME"
                32 |   }
                33 | 
                34 |   dynamic "host" {
                35 |     for_each = yandex_vpc_subnet.develop
                36 |     content {
                37 |       zone = host.value.zone
                38 |       subnet_id = host.value.id
                39 |       name = host.value.name
                40 |     }
                41 |   }
                42 | }

secrets scan results:

Passed checks: 0, Failed checks: 1, Skipped checks: 0

Check: CKV_SECRET_6: "Base64 High Entropy String"
        FAILED for resource: 24e7451df05ed5cd4cf1041be67c68f8d89d087a
        File: /providers.tf:33-34

                33 |  token = "ed*******"


 terraform plan
Acquiring state lock. This may take a few moments...
data.template_file.cloudinit: Reading...
data.template_file.cloudinit: Read complete after 0s [id=88494dac047b6257c9dc09991d8e634b2f3574b5fe9f8beed31c079c755e4c51]
data.vault_generic_secret.vault_example: Reading...
data.vault_generic_secret.vault_example: Read complete after 0s [id=secret/example]
module.test-vm.data.yandex_compute_image.my_image: Reading...
module.test-vm.data.yandex_compute_image.my_image: Read complete after 4s [id=fd8mkq33tt9kvi2c10e5]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # vault_generic_secret.my_secret will be created
  + resource "vault_generic_secret" "my_secret" {
      + data         = (sensitive value)
      + data_json    = (sensitive value)
      + disable_read = false
      + id           = (known after apply)
      + path         = "secret/very_imprtant"
    }

  # yandex_vpc_network.develop will be created
  + resource "yandex_vpc_network" "develop" {
      + created_at                = (known after apply)
      + default_security_group_id = (known after apply)
      + folder_id                 = (known after apply)
      + id                        = (known after apply)
      + labels                    = (known after apply)
      + name                      = "develop"
      + subnet_ids                = (known after apply)
    }

  # yandex_vpc_subnet.develop will be created
  + resource "yandex_vpc_subnet" "develop" {
      + created_at     = (known after apply)
      + folder_id      = (known after apply)
      + id             = (known after apply)
      + labels         = (known after apply)
      + name           = "develop-ru-central1-a"
      + network_id     = (known after apply)
      + v4_cidr_blocks = [
          + "10.0.1.0/24",
        ]
      + v6_cidr_blocks = (known after apply)
      + zone           = "ru-central1-a"
    }

  # module.test-vm.yandex_compute_instance.vm[0] will be created
  + resource "yandex_compute_instance" "vm" {
      + allow_stopping_for_update = true
      + created_at                = (known after apply)
      + description               = "TODO: description; {{terraform managed}}"
      + folder_id                 = (known after apply)
      + fqdn                      = (known after apply)
      + gpu_cluster_id            = (known after apply)
      + hostname                  = "develop-web-0"
      + id                        = (known after apply)
      + labels                    = {
          + "env"     = "develop"
          + "project" = "undefined"
        }
      + metadata                  = {
          + "serial-port-enable" = "1"
          + "user-data"          = <<-EOT
                #cloud-config
                users:
                  - name: ubuntu
                    groups: sudo
                    shell: /bin/bash
                    sudo: ['ALL=(ALL) NOPASSWD:ALL']
                    ssh_authorized_keys:
                      - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILroHnVVBk9mPo8RNp6OEy2yfY47sOhO4WhtixAINpNS beatl@ProBookB
                "
                      - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDhSV7Ub5OKiYZm6e/w0cb8MQb+7R4E+yPNWT4moppbmfn8CJBXIp0xdiAmYiZYReUDEqZH0lYqxgQH5Or2MtyNC+MnISOttyF7oRSCUWdpfiJshpQfw/wLkmLqnWmQdovgTfPu5KW5yZYU0opGUv+Zgybqy3okbQURsI8ypXXSvv4ARzyLOJu5mTui822b1Pr7HI/Kxug9nMtKJs/AHuf5lnqQKp/Jt+fYeZuxHGKJ1Ynv+n7GWnmSV/pYjkG4Om6wOjBvPEq+hO+paaGQSe5EGY6+pKam4WMFjRiCUgrk5Haw5kfmw61todMrUZ7Hdwx/uqH2aQM8b47zveidMjPARQ+unqL6X/j/qhFOuFH6ObQJ76s/QTZiqgx6lQilU/i1hu3R3EpVJ3RqwqPFxOCl8TDt0em6Fco5AjgBlG3VGEnkcXqHPvK3befI7GVqaWUgvRzcYJrgtdykEU4xhXYTJh8lturr6mno3YIRzw6mUMwfABvODrIgCm7kWwkcSAs= beatl@ProBookB
                "
                package_update: true
                package_upgrade: false
                packages:
                 - vim
                 - nginx
            EOT
        }
      + name                      = "develop-web-0"
      + network_acceleration_type = "standard"
      + platform_id               = "standard-v1"
      + service_account_id        = (known after apply)
      + status                    = (known after apply)
      + zone                      = "ru-central1-a"

      + boot_disk {
          + auto_delete = true
          + device_name = (known after apply)
          + disk_id     = (known after apply)
          + mode        = (known after apply)

          + initialize_params {
              + block_size  = (known after apply)
              + description = (known after apply)
              + image_id    = "fd8mkq33tt9kvi2c10e5"
              + name        = (known after apply)
              + size        = 10
              + snapshot_id = (known after apply)
              + type        = "network-hdd"
            }
        }

      + network_interface {
          + index              = (known after apply)
          + ip_address         = (known after apply)
          + ipv4               = true
          + ipv6               = (known after apply)
          + ipv6_address       = (known after apply)
          + mac_address        = (known after apply)
          + nat                = true
          + nat_ip_address     = (known after apply)
          + nat_ip_version     = (known after apply)
          + security_group_ids = (known after apply)
          + subnet_id          = (known after apply)
        }

      + resources {
          + core_fraction = 5
          + cores         = 2
          + memory        = 1
        }

      + scheduling_policy {
          + preemptible = true
        }
    }

Plan: 4 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + vault_example = {
      + my_secret = "Big secret for little company"
    }

─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform apply" now.
Releasing state lock. This may take a few moments...
```